### PR TITLE
Add Fedora Linux (Copr) package

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ sudo ninja -C builddir install
 |:-:|:-:|:-:|
 | Ubuntu (PPA) | [`Stable Releases`](https://launchpad.net/~apandada1/+archive/ubuntu/webfontkitgenerator), [`Daily Builds`](https://launchpad.net/~apandada1/+archive/ubuntu/webfontkitgenerator-daily) | [Archisman Panigrahi](https://github.com/apandada1) |
 | Arch Linux (AUR) | [`webfontkitgenerator-git`](https://aur.archlinux.org/packages/webfontkitgenerator-git/) | [Archisman Panigrahi](https://github.com/apandada1) |
+| Fedora Linux (Copr) | [`webfont-kit-generator`](https://copr.fedorainfracloud.org/coprs/xfgusta/webfont-kit-generator/) | [Gustavo Costa](https://github.com/xfgusta)|
 
 > It would be great if you can help us by building native packages for Fedora, Solus and other major distributions, and get them included in the official repositories.
 


### PR DESCRIPTION
The spec file follows the [Fedora Packaging Guidelines](https://docs.fedoraproject.org/en-US/packaging-guidelines/). Here it is:

<details open>

```spec
%global         appname webfontkitgenerator
%global         appid com.rafaelmardojai.WebfontKitGenerator

Name:           webfont-kit-generator
Version:        0.4.0
Release:        2%{?dist}
Summary:        Create @font-face kits easily 

License:        GPLv3
URL:            https://github.com/rafaelmardojai/webfont-kit-generator
Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz

BuildArch:      noarch

BuildRequires:  meson
BuildRequires:  python3-devel
BuildRequires:  python3-gobject-devel
BuildRequires:  libhandy1-devel
BuildRequires:  gettext
BuildRequires:  desktop-file-utils
BuildRequires:  libappstream-glib

Requires:       hicolor-icon-theme
Requires:       python3-gobject
Requires:       libhandy1
Requires:       python3dist(fonttools)

%description
Webfont Kit Generator is a simple utility that allows you to generate woff, 
woff2 and the necessary CSS boilerplate from non-web font formats (otf & ttf).


%prep
%autosetup


%build
%meson
%meson_build


%install
%meson_install
%find_lang %{appname}


%check
appstream-util validate-relax --nonet %{buildroot}%{_metainfodir}/%{appid}.metainfo.xml
desktop-file-validate %{buildroot}/%{_datadir}/applications/%{appid}.desktop


%files -f %{appname}.lang
%license COPYING
%doc README.md
%{_bindir}/%{appname}
%{_datadir}/%{appname}
%{_datadir}/applications/%{appid}.desktop
%{_datadir}/icons/hicolor/*/apps/*
%{_datadir}/glib-2.0/schemas/%{appid}.gschema.xml
%{_metainfodir}/%{appid}.metainfo.xml



%changelog
* Sat Jul 10 2021 Gustavo Costa <xfgusta@fedoraproject.org> - 0.4.0-2
- Add libhandy as a runtime dependency

* Wed Jun 30 2021 Gustavo Costa <xfgusta@fedoraproject.org> - 0.4.0-1
- Initial package
```

</details>