### PR TITLE
Add option to embed font in CSS as base64

### DIFF
--- a/data/com.rafaelmardojai.WebfontKitGenerator.gschema.xml
+++ b/data/com.rafaelmardojai.WebfontKitGenerator.gschema.xml
@@ -36,6 +36,9 @@
         <default>false</default>
     </key>
 
+    <key type="b" name="base64">
+        <default>false</default>
+    </key>
     <key type="i" name="font-display">
         <default>0</default>
     </key>

--- a/webfontkitgenerator/options.blp
+++ b/webfontkitgenerator/options.blp
@@ -172,6 +172,11 @@ template $Options : Adw.PreferencesPage {
   Adw.PreferencesGroup {
     title: _("CSS");
 
+    Adw.SwitchRow base64 {
+      title: _("Base64 Encode");
+      subtitle: _("Embed fonts in the CSS");
+    }
+
     Adw.ComboRow font_display {
       title: _("Font display");
       subtitle: _("The CSS font-display descriptor");

--- a/webfontkitgenerator/options.py
+++ b/webfontkitgenerator/options.py
@@ -44,6 +44,7 @@ class Options(Adw.PreferencesPage):
     custom: Gtk.Entry = Gtk.Template.Child()
 
     # CSS
+    base64: Adw.SwitchRow = Gtk.Template.Child()
     font_display: Adw.ComboRow = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
@@ -58,7 +59,7 @@ class Options(Adw.PreferencesPage):
 
     def load_saved(self):
         # Generate list of toggle names
-        toggles = ['woff2', 'woff']
+        toggles = ['woff2', 'woff', 'base64']
         toggles.extend(PRESET_RANGES.keys())  # latin, latin_ext, etc
 
         for name in toggles:
@@ -122,6 +123,9 @@ class Options(Adw.PreferencesPage):
             return None
 
         return ranges
+
+    def get_base64(self) -> bool:
+        return self.base64.props.active
 
     def get_font_display(self) -> str | None:
         if self.font_display.props.selected == 0:

--- a/webfontkitgenerator/window.py
+++ b/webfontkitgenerator/window.py
@@ -181,6 +181,7 @@ class Window(Adw.ApplicationWindow):
             self.model,
             self.options.get_formats(),
             self.options.get_subsetting(),
+            self.options.get_base64(),
             self.options.get_font_display(),
         )
         generator.run()


### PR DESCRIPTION
Fixes #38 

![Captura desde 2023-07-20 11-51-01](https://github.com/rafaelmardojai/webfont-kit-generator/assets/6210397/1ea88f70-9079-4578-a528-28dee39968e3)

Haven't tested yet if the resulting CSS is functional.