### PR TITLE
Appstream related patches

### DIFF
--- a/data/com.rafaelmardojai.WebfontKitGenerator.desktop.in
+++ b/data/com.rafaelmardojai.WebfontKitGenerator.desktop.in
@@ -6,5 +6,7 @@ Icon=com.rafaelmardojai.WebfontKitGenerator
 Terminal=false
 Type=Application
 Categories=Utility;GTK;
+# Translators: Search terms to find this application. Do NOT translate or localize the semicolons! The list MUST also end with a semicolon!
+Keywords=font;font-face;
 StartupNotify=true
 MimeType=font/otf;font/ttf;

--- a/data/com.rafaelmardojai.WebfontKitGenerator.metainfo.xml.in
+++ b/data/com.rafaelmardojai.WebfontKitGenerator.metainfo.xml.in
@@ -13,15 +13,19 @@
       Webfont Kit Generator also includes a tool to Download fonts from Google Fonts for self-hosting.
     </p>
   </description>  
-  <url type="homepage">https://apps.gnome.org/es/app/com.rafaelmardojai.WebfontKitGenerator/</url>
+  <url type="homepage">https://apps.gnome.org/WebfontKitGenerator/</url>
   <url type="vcs-browser">https://github.com/rafaelmardojai/webfont-kit-generator/</url>
   <url type="bugtracker">https://github.com/rafaelmardojai/webfont-kit-generator/issues</url>
   <url type="translate">https://www.transifex.com/rafaelmardojai/webfont-kit-generator/</url>
   <url type="donation">https://rafaelmardojai.com/donate/</url>
-  <developer_name>Rafael Mardojai CM</developer_name>
+  <developer_name translatable="no">Rafael Mardojai CM</developer_name>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>
   <content_rating type="oars-1.1" />
   
+  <categories>
+    <category>Utility</category>
+    <category>GTK</category>
+  </categories>
   <launchable type="desktop-id">com.rafaelmardojai.WebfontKitGenerator.desktop</launchable>
   <translation type="gettext">webfontkitgenerator</translation>
 

--- a/data/com.rafaelmardojai.WebfontKitGenerator.metainfo.xml.in
+++ b/data/com.rafaelmardojai.WebfontKitGenerator.metainfo.xml.in
@@ -26,6 +26,11 @@
     <category>Utility</category>
     <category>GTK</category>
   </categories>
+  <keywords>
+    <keyword>font</keyword>
+    <keyword>font-face</keyword>
+  </keywords>
+  
   <launchable type="desktop-id">com.rafaelmardojai.WebfontKitGenerator.desktop</launchable>
   <translation type="gettext">webfontkitgenerator</translation>
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -22,10 +22,10 @@ appstream_file = i18n.merge_file(
   install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
-appstream_util = find_program('appstream-util', required: false)
-if appstream_util.found()
-  test('Validate appstream file', appstream_util,
-    args: ['validate-relax', appstream_file]
+appstreamcli = find_program('appstreamcli', required: false)
+if appstreamcli.found()
+  test('Validate appstream file', appstreamcli,
+    args: ['validate', '--no-net', appstream_file]
   )
 endif
 


### PR DESCRIPTION
### appdata: use appstreamcli for appdata validation

appstream-util is obsoleted by appstreamcli.

### data: Update appdata

- Update homepage with new URL
- Mark the developer name as untranslatable
- Add categories

### data: Add keywords support

These keywords can use to search the application.
