### PR TITLE
appdata: Improve appdata for AppStream 1.0

### DIFF
--- a/com.rafaelmardojai.WebfontKitGenerator.json
+++ b/com.rafaelmardojai.WebfontKitGenerator.json
@@ -56,6 +56,7 @@
             "name" : "webfontkitgenerator",
             "builddir" : true,
             "buildsystem" : "meson",
+            "run-tests" : true,
             "sources" : [
                 {
                     "type" : "dir",

--- a/data/com.rafaelmardojai.WebfontKitGenerator.metainfo.xml.in
+++ b/data/com.rafaelmardojai.WebfontKitGenerator.metainfo.xml.in
@@ -18,7 +18,11 @@
   <url type="bugtracker">https://github.com/rafaelmardojai/webfont-kit-generator/issues</url>
   <url type="translate">https://www.transifex.com/rafaelmardojai/webfont-kit-generator/</url>
   <url type="donation">https://rafaelmardojai.com/donate/</url>
+  <!-- developer_name tag deprecated with Appstream 1.0 -->
   <developer_name translatable="no">Rafael Mardojai CM</developer_name>
+  <developer id="github.com">
+      <name translatable="no">Rafael Mardojai CM</name>
+  </developer>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>
   <content_rating type="oars-1.1" />
   <launchable type="desktop-id">com.rafaelmardojai.WebfontKitGenerator.desktop</launchable>

--- a/data/com.rafaelmardojai.WebfontKitGenerator.metainfo.xml.in
+++ b/data/com.rafaelmardojai.WebfontKitGenerator.metainfo.xml.in
@@ -21,16 +21,6 @@
   <developer_name translatable="no">Rafael Mardojai CM</developer_name>
   <update_contact>email_AT_rafaelmardojai.com</update_contact>
   <content_rating type="oars-1.1" />
-  
-  <categories>
-    <category>Utility</category>
-    <category>GTK</category>
-  </categories>
-  <keywords>
-    <keyword>font</keyword>
-    <keyword>font-face</keyword>
-  </keywords>
-  
   <launchable type="desktop-id">com.rafaelmardojai.WebfontKitGenerator.desktop</launchable>
   <translation type="gettext">webfontkitgenerator</translation>
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -25,7 +25,8 @@ appstream_file = i18n.merge_file(
 appstreamcli = find_program('appstreamcli', required: false)
 if appstreamcli.found()
   test('Validate appstream file', appstreamcli,
-    args: ['validate', '--no-net', appstream_file]
+    args: ['validate', '--no-net', '--explain', appstream_file],
+    workdir: meson.current_build_dir()
   )
 endif
 


### PR DESCRIPTION
### appdata: Improve appdata for AppStream 1.0

- Add the `<developer><name>` tag
- Mark the `<developer_name>` tag as deprecated
- Improve appstreamcli parameters

### appdata: Fix my mistake

"Icons and categories

If there’s a type="desktop-id" launchable, they get pulled from it.
Most of the icon not found errors with the flathub builder can be
traced down to the launchable value not matching the desktop file name.

Don’t set them in the AppData unless you want to override them
(even though then it might be a better idea to patch the desktop file
itself)."

More information: https://docs.flathub.org/docs/for-app-authors/appdata-guidelines/#icons-and-categories