### PR TITLE
google: fix getting phase

### DIFF
--- a/webfontkitgenerator/google.py
+++ b/webfontkitgenerator/google.py
@@ -122,7 +122,7 @@ class GoogleDialog(Adw.Dialog):
             response_headers = message.get_response_headers()
 
             print(
-                f'Google Fonts Response Status {status.get_phrase(status_code)}'
+                f'Google Fonts Response Status {status.get_phrase()}'
             )
 
             if status == Soup.Status.OK and 'kind' in data:


### PR DESCRIPTION
This fixes the following error using PyGObject 3.52.3 and libsoup 3.6.5:
```
Traceback (most recent call last):
  File "/usr/share/webfontkitgenerator/webfontkitgenerator/google.py", line 125, in on_google_response
    f'Google Fonts Response Status {status.get_phrase(status_code)}'
                                    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
TypeError: Soup.Status.get_phrase() takes exactly 1 argument (2 given)
```